### PR TITLE
using Dynamic keyword for ExprTyper

### DIFF
--- a/Parser/ExprTyper.cs
+++ b/Parser/ExprTyper.cs
@@ -11,10 +11,10 @@ class ExprTyper : Visitor<NType> {
       => identifier.Type = NType.Int;
 
    public override NType Visit (NUnary unary)
-      => unary.Type = unary.Expr.Accept (this);
+      => unary.Type = Visit(unary.Expr as dynamic);
 
    public override NType Visit (NBinary binary) {
-      NType a = binary.Left.Accept (this), b = binary.Right.Accept (this);
+      NType a = Visit(binary.Left as dynamic), b = Visit(binary.Right as dynamic);
       return binary.Type = (a, binary.Op.Kind, b) switch {
          (NType.Real or NType.Int, ADD or SUB or MUL or DIV, NType.Real or NType.Int) => a == b ? a : NType.Real, 
          (NType.String or _, ADD, _ or NType.String) => NType.String,

--- a/Parser/Start.cs
+++ b/Parser/Start.cs
@@ -10,7 +10,7 @@ static class Start {
          var node = expr;
 
          ExprTyper exprTyper = new ();
-         Console.WriteLine ("Expression Type: " + node.Accept (exprTyper));
+         Console.WriteLine ("Expression Type: " + exprTyper.Visit (node as dynamic));
 
          var dict = new Dictionary<string, double> () { ["five"] = 5, ["two"] = 2 };
          double value = node.Accept (new ExprEvaluator (dict));


### PR DESCRIPTION
I was curious to see if we can replace the visitor pattern or just simplify it by using the dynamic keyword since it basically does the same thing (implements multiple dispatch). I tried using it in the ExprTyper in this project, but I'm not entirely sure if this is the correct usage (it works, but unsure if there's a simpler, more appropriate way to do this)